### PR TITLE
Correção p/ PHP 7.4

### DIFF
--- a/src/CNPJ.php
+++ b/src/CNPJ.php
@@ -39,22 +39,22 @@ class CNPJ extends DocumentoAbstract
 
         // Validate first check digit
         for ($i = 0, $j = 5, $sum = 0; $i < 12; $i++) {
-            $sum += $this->value{$i} * $j;
+            $sum += $this->value[$i] * $j;
             $j = ($j == 2) ? 9 : $j - 1;
         }
         $result = $sum % 11;
 
-        if ($this->value{12} != ($result < 2 ? 0 : 11 - $result))
+        if ($this->value[12] != ($result < 2 ? 0 : 11 - $result))
             return false;
 
         // Validate second check digit
         for ($i = 0, $j = 6, $sum = 0; $i < 13; $i++) {
-            $sum += $this->value{$i} * $j;
+            $sum += $this->value[$i] * $j;
             $j = ($j == 2) ? 9 : $j - 1;
         }
         $result = $sum % 11;
 
-        return $this->value{13} == ($result < 2 ? 0 : 11 - $result);
+        return $this->value[13] == ($result < 2 ? 0 : 11 - $result);
     }
 
     /**

--- a/src/CPF.php
+++ b/src/CPF.php
@@ -39,20 +39,20 @@ class CPF extends DocumentoAbstract
 
         // Validate first check digit
         for ($i = 0, $j = 10, $sum = 0; $i < 9; $i++, $j--)
-            $sum += $this->value{$i} * $j;
+            $sum += $this->value[$i] * $j;
 
         $result = $sum % 11;
 
-        if ($this->value{9} != ($result < 2 ? 0 : 11 - $result))
+        if ($this->value[9] != ($result < 2 ? 0 : 11 - $result))
             return false;
 
         // Validate first second digit
         for ($i = 0, $j = 11, $sum = 0; $i < 10; $i++, $j--)
-            $sum += $this->value{$i} * $j;
+            $sum += $this->value[$i] * $j;
 
         $result = $sum % 11;
 
-        return $this->value{10} == ($result < 2 ? 0 : 11 - $result);
+        return $this->value[10] == ($result < 2 ? 0 : 11 - $result);
     }
 
     /**


### PR DESCRIPTION
Boa Noite @bissolli 

Com o lançamento oficial do PHP 7.4 em Dezembro de 2019, algumas coisas mudaram.

Ao fazer upgrade do PHP p/ nova versão, me deparei com o seguinte erro:

```
ERROR: Array and string offset access syntax with curly braces is deprecated on line 55 in file \/app\/vendor\/bissolli\/validador-cpf-cnpj\/src\/CPF.php.
```

Ao verificar sobre o problema, descobri que passou uma RFC para o PHP 7.4, que deprecia usar `{}` para acessar itens de array https://wiki.php.net/rfc/deprecate_curly_braces_array_access

Fiz fork e abro essa PR para ajudar com a correção, assim seu pacote continuará funcional para futuras  versões :+1:

[]'s!